### PR TITLE
Handle invalid json

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,13 @@ var hn = {
     request(query, function (error, response, body) {
       if (!error && response.statusCode != 200)
         error = response.statusCode;
-      if (typeof body !== 'undefined')
-        body = JSON.parse(body);
+      if (typeof body !== 'undefined') {
+        try {
+          body = JSON.parse(body);
+        } catch(ex) {
+          if(!error) error = ex;
+        }
+      }
       cb(error, body);
     });
   },


### PR DESCRIPTION
If a hacker news item doesn't exist, the api returns a 404 as well as invalid json which looks something like `GET https://UJ5WYC0L7X-2.algolia.io/1/indexes/Item_production/7?params=advancedSyntax%3Dtrue%26analytics%3Dfalse: {"message":"ObjectID does not exist"}` resulting in `SyntaxError: Unexpected token G`. Your current code attempts to run JSON.parse even if statusCode != 200, and thus fails on this case. I think that doing a try-catch there is appropriate. If the resulting body was not parsed correctly, error will always be set.

The minimal failing example is:

```
require('hacker-news-api').getItem(7, console.log);
```

since the item with id '7' is deleted or something (I can actually see [it](https://news.ycombinator.com/item?id=7) fine)
